### PR TITLE
Try to exclude all non electric cars

### DIFF
--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -45,11 +45,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         vehicles = []
 
         for vin, vehicle in _we_connect.vehicles.items():
-            car_type = get_object_value(
-                vehicle.domains["fuelStatus"]["rangeStatus"].carType
-            )
-            if car_type == RangeStatus.CarType.ELECTRIC.value:
-                vehicles.append(vehicle)
+            try:
+                car_type = get_object_value(
+                    vehicle.domains["fuelStatus"]["rangeStatus"].carType
+                )
+                if car_type == RangeStatus.CarType.ELECTRIC.value:
+                    vehicles.append(vehicle)
+            except Exception as fail:
+                # This will not add cars that don't have 'fuelStatus' in their domains
+                pass
 
         hass.data[DOMAIN][entry.entry_id + "_vehicles"] = vehicles
         return vehicles

--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -45,13 +45,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         vehicles = []
 
         for vin, vehicle in _we_connect.vehicles.items():
-            if 'fuelStatus' in vehicle.domains:
-                if 'rangeStatus' in vehicle.domains["fuelStatus"]:
-                    car_type = get_object_value(
-                        vehicle.domains["fuelStatus"]["rangeStatus"].carType
-                    )
-                    if car_type == RangeStatus.CarType.ELECTRIC.value:
-                        vehicles.append(vehicle)
+            if "ID".casefold() in vehicle.model.value.casefold():
+                vehicles.append(vehicle)
 
         hass.data[DOMAIN][entry.entry_id + "_vehicles"] = vehicles
         return vehicles

--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -45,15 +45,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         vehicles = []
 
         for vin, vehicle in _we_connect.vehicles.items():
-            try:
-                car_type = get_object_value(
-                    vehicle.domains["fuelStatus"]["rangeStatus"].carType
-                )
-                if car_type == RangeStatus.CarType.ELECTRIC.value:
-                    vehicles.append(vehicle)
-            except Exception as fail:
-                # This will not add cars that don't have 'fuelStatus' in their domains
-                pass
+            if 'fuelStatus' in vehicle.domains:
+                if 'rangeStatus' in vehicle.domains["fuelStatus"]:
+                    car_type = get_object_value(
+                        vehicle.domains["fuelStatus"]["rangeStatus"].carType
+                    )
+                    if car_type == RangeStatus.CarType.ELECTRIC.value:
+                        vehicles.append(vehicle)
 
         hass.data[DOMAIN][entry.entry_id + "_vehicles"] = vehicles
         return vehicles


### PR DESCRIPTION
Hi Mitch,

i've tried to exclude cars that have no 'fuel-status' in their domains from the list. 
This worked for me with my Tiguan and ID.3. My Tiguan will run the exception clause whereas my ID.3 will run the try clause through and i have no error in the start of home_assistant. If you like i could reset my changed environment to make the exception clause a bit or narrow, but i think for future stability this will just catch all issues.

regards

Dominik 