### PR TITLE
Enable timeout for connections to weconnect

### DIFF
--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -34,6 +34,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         password=entry.data["password"],
         updateAfterLogin=False,
         loginOnInit=False,
+        timeout=10
     )
 
     await hass.async_add_executor_job(_we_connect.login)
@@ -43,7 +44,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Fetch data from Volkswagen API."""
         _LOGGER.info("Fetching data from VW API...")
         await hass.async_add_executor_job(_we_connect.update)
-
+        _LOGGER.info("Data retrieved")
         vehicles = []
 
         for vin, vehicle in _we_connect.vehicles.items():
@@ -51,7 +52,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 vehicles.append(vehicle)
 
         hass.data[DOMAIN][entry.entry_id + "_vehicles"] = vehicles
-        _LOGGER.info("Data retrieved")
+        
         return vehicles
 
     coordinator = DataUpdateCoordinator(

--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -42,9 +42,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def async_update_data():
         """Fetch data from Volkswagen API."""
-        _LOGGER.info("Fetching data from VW API...")
         await hass.async_add_executor_job(_we_connect.update)
-        _LOGGER.info("Data retrieved")
         vehicles = []
 
         for vin, vehicle in _we_connect.vehicles.items():

--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -41,6 +41,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def async_update_data():
         """Fetch data from Volkswagen API."""
+        _LOGGER.info("Fetching data from VW API...")
         await hass.async_add_executor_job(_we_connect.update)
 
         vehicles = []
@@ -50,6 +51,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 vehicles.append(vehicle)
 
         hass.data[DOMAIN][entry.entry_id + "_vehicles"] = vehicles
+        _LOGGER.info("Data retrieved")
         return vehicles
 
     coordinator = DataUpdateCoordinator(

--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -43,6 +43,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def async_update_data():
         """Fetch data from Volkswagen API."""
         await hass.async_add_executor_job(_we_connect.update)
+
         vehicles = []
 
         for vin, vehicle in _we_connect.vehicles.items():
@@ -50,7 +51,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 vehicles.append(vehicle)
 
         hass.data[DOMAIN][entry.entry_id + "_vehicles"] = vehicles
-        
         return vehicles
 
     coordinator = DataUpdateCoordinator(

--- a/custom_components/volkswagen_we_connect_id/manifest.json
+++ b/custom_components/volkswagen_we_connect_id/manifest.json
@@ -3,7 +3,7 @@
   "name": "Volkswagen We Connect ID",
   "config_flow": true,
   "documentation": "https://github.com/mitch-dc/volkswagen_we_connect_id",
-  "requirements": ["weconnect==0.42.0", "ascii_magic==1.6"],
+  "requirements": ["weconnect==0.44.0", "ascii_magic==1.6"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/volkswagen_we_connect_id/manifest.json
+++ b/custom_components/volkswagen_we_connect_id/manifest.json
@@ -3,7 +3,7 @@
   "name": "Volkswagen We Connect ID",
   "config_flow": true,
   "documentation": "https://github.com/mitch-dc/volkswagen_we_connect_id",
-  "requirements": ["weconnect==0.44.0", "ascii_magic==1.6"],
+  "requirements": ["weconnect==0.40", "ascii_magic==1.6"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/volkswagen_we_connect_id/manifest.json
+++ b/custom_components/volkswagen_we_connect_id/manifest.json
@@ -3,7 +3,7 @@
   "name": "Volkswagen We Connect ID",
   "config_flow": true,
   "documentation": "https://github.com/mitch-dc/volkswagen_we_connect_id",
-  "requirements": ["weconnect==0.42", "ascii_magic==1.6"],
+  "requirements": ["weconnect==0.42.0", "ascii_magic==1.6"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/volkswagen_we_connect_id/manifest.json
+++ b/custom_components/volkswagen_we_connect_id/manifest.json
@@ -3,7 +3,7 @@
   "name": "Volkswagen We Connect ID",
   "config_flow": true,
   "documentation": "https://github.com/mitch-dc/volkswagen_we_connect_id",
-  "requirements": ["weconnect==0.40", "ascii_magic==1.6"],
+  "requirements": ["weconnect==0.44.2", "ascii_magic==1.6"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},


### PR DESCRIPTION
Should fix #36.

I've not had a recurrence of the issue since I enabled this locally, but I can't be sure it's fixed. In any case it's probably a good idea to enable this timeout.

Value of 10s is a bit arbitrary but seems sensible.