### PR TITLE
Restore binary sensors

### DIFF
--- a/custom_components/volkswagen_we_connect_id/binary_sensor.py
+++ b/custom_components/volkswagen_we_connect_id/binary_sensor.py
@@ -101,6 +101,28 @@ SENSORS: tuple[VolkswagenIdBinaryEntityDescription, ...] = (
         device_class=BinarySensorDeviceClass.LOCK,
         on_value=PlugStatus.PlugLockState.UNLOCKED,
     ),
+    VolkswagenIdBinaryEntityDescription(
+        key="insufficientBatteryLevelWarning",
+        name="Insufficient Battery Level Warning",
+        value=lambda data: data["readiness"][
+            "readinessStatus"
+        ].connectionWarning.insufficientBatteryLevelWarning.value,
+    ),
+    VolkswagenIdBinaryEntityDescription(
+        name="Car Is Online",
+        key="isOnline",
+        value=lambda data: data["readiness"][
+            "readinessStatus"
+        ].connectionState.isOnline.value,
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+    ),
+    VolkswagenIdBinaryEntityDescription(
+        name="Car Is Active",
+        key="isActive",
+        value=lambda data: data["readiness"][
+            "readinessStatus"
+        ].connectionState.isActive.value,
+    ),
 )
 
 
@@ -145,10 +167,13 @@ class VolkswagenIDSensor(VolkswagenIDBaseEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return true if sensor is on."""
+        try:
+          state = self.entity_description.value(self.data.domains)
+          if isinstance(state, bool):
+              return state
 
-        state = self.entity_description.value(self.data.domains)
-        if isinstance(state, bool):
-            return state
+          state = get_object_value(state)
+          return state == get_object_value(self.entity_description.on_value)
 
-        state = get_object_value(state)
-        return state == get_object_value(self.entity_description.on_value)
+        except KeyError:
+          return None

--- a/custom_components/volkswagen_we_connect_id/manifest.json
+++ b/custom_components/volkswagen_we_connect_id/manifest.json
@@ -3,7 +3,7 @@
   "name": "Volkswagen We Connect ID",
   "config_flow": true,
   "documentation": "https://github.com/mitch-dc/volkswagen_we_connect_id",
-  "requirements": ["weconnect==0.45.0", "ascii_magic==1.6"],
+  "requirements": ["weconnect==0.45.1", "ascii_magic==1.6"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},


### PR DESCRIPTION
Fix for issue https://github.com/mitch-dc/volkswagen_we_connect_id/issues/56

I have also protected the API call with `try` and `except` so if the attributes dissapear again, the integration should handle the error better.