### PR TITLE
Add a timeout to the async update of weconnect data

### DIFF
--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -53,7 +53,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
             update_elapsed = time.perf_counter() - before_update
             if update_elapsed > 10:
-                _LOGGER.info("weconnect update took {update_elapsed:.1f}s")    
+                _LOGGER.info(F"weconnect update took {update_elapsed:.1f}s")    
 
         except asyncio.TimeoutError:
             _LOGGER.error("Timeout updating weconnect")

--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -46,12 +46,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Fetch data from Volkswagen API."""
 
         try:
-            before_update = time.time()
+            before_update = time.perf_counter()
             await asyncio.wait_for(
                 hass.async_add_executor_job(_we_connect.update),
                 timeout=120.0
             )
-            update_elapsed = time.time() - before_update
+            update_elapsed = time.perf_counter() - before_update
             if update_elapsed > 10:
                 _LOGGER.info("weconnect update took {update_elapsed:.1f}s")    
 

--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -47,7 +47,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def async_update_data():
         """Fetch data from Volkswagen API."""
        
-        await hass.async_add_executor_job(_we_connect.update)
+        try:
+            await asyncio.wait_for(
+                hass.async_add_executor_job(_we_connect.update),
+                timeout=30.0
+            )
+        except asyncio.TimeoutError:
+            _LOGGER.error("Timeout updating weconnect")
+            return
+ 
 
         vehicles = []
 

--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -46,7 +46,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def async_update_data():
         """Fetch data from Volkswagen API."""
-        await asyncio.wait_for(hass.async_add_executor_job(_we_connect.update), timeout=15)
+        await asyncio.wait_for(hass.async_add_executor_job(_we_connect.update), timeout=30.0)
 
         vehicles = []
 

--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -52,8 +52,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 timeout=120.0
             )
             update_elapsed = time.perf_counter() - before_update
-            if update_elapsed > 10:
-                _LOGGER.info(F"weconnect update took {update_elapsed:.1f}s")    
+            if update_elapsed > 30:
+                _LOGGER.warn(F"weconnect update took {update_elapsed:.1f}s")    
 
         except asyncio.TimeoutError:
             _LOGGER.error("Timeout updating weconnect")

--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -38,8 +38,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         timeout=10
     )
 
+    _LOGGER.info("tsg21 version")
+
     await hass.async_add_executor_job(_we_connect.login)
     await hass.async_add_executor_job(_we_connect.update)
+
 
     async def async_update_data():
         """Fetch data from Volkswagen API."""

--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -46,12 +46,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Fetch data from Volkswagen API."""
 
         try:
-            before_update = time()
+            before_update = time.time()
             await asyncio.wait_for(
                 hass.async_add_executor_job(_we_connect.update),
                 timeout=120.0
             )
-            update_elapsed = time() - before_update
+            update_elapsed = time.time() - before_update
             if update_elapsed > 10:
                 _LOGGER.info("weconnect update took {update_elapsed:.1f}s")    
 

--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 import logging
+import asyncio
 
 from weconnect import weconnect
 from weconnect.elements.control_operation import ControlOperation
@@ -42,7 +43,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def async_update_data():
         """Fetch data from Volkswagen API."""
-        await hass.async_add_executor_job(_we_connect.update)
+        await asyncio.wait_for(hass.async_add_executor_job(_we_connect.update), timeout=15)
 
         vehicles = []
 

--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -73,7 +73,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER,
         name=DOMAIN,
         update_method=async_update_data,
-        update_interval=timedelta(seconds=30),
+        update_interval=timedelta(seconds=300),
     )
 
     hass.data.setdefault(DOMAIN, {})

--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -46,7 +46,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def async_update_data():
         """Fetch data from Volkswagen API."""
-        await asyncio.wait_for(hass.async_add_executor_job(_we_connect.update), timeout=30.0)
+       
+        await hass.async_add_executor_job(_we_connect.update)
 
         vehicles = []
 

--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -73,7 +73,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER,
         name=DOMAIN,
         update_method=async_update_data,
-        update_interval=timedelta(seconds=300),
+        update_interval=timedelta(seconds=30),
     )
 
     hass.data.setdefault(DOMAIN, {})

--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 import asyncio
-
+import time
+from turtle import update
 from weconnect import weconnect
 from weconnect.elements.control_operation import ControlOperation
 
@@ -37,25 +38,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         loginOnInit=False,
         timeout=10
     )
-
-    _LOGGER.info("tsg21 version")
-
+    
     await hass.async_add_executor_job(_we_connect.login)
     await hass.async_add_executor_job(_we_connect.update)
 
 
     async def async_update_data():
         """Fetch data from Volkswagen API."""
-       
+
         try:
+            before_update = time()
             await asyncio.wait_for(
                 hass.async_add_executor_job(_we_connect.update),
-                timeout=30.0
+                timeout=120.0
             )
+            update_elapsed = time() - before_update
+            if update_elapsed > 10:
+                _LOGGER.info("weconnect update took {update_elapsed:.1f}s")    
+
         except asyncio.TimeoutError:
             _LOGGER.error("Timeout updating weconnect")
             return
- 
 
         vehicles = []
 

--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 import logging
 import asyncio
 import time
-from turtle import update
 from weconnect import weconnect
 from weconnect.elements.control_operation import ControlOperation
 

--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -43,6 +43,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def async_update_data():
         """Fetch data from Volkswagen API."""
         await hass.async_add_executor_job(_we_connect.update)
+
         vehicles = []
 
         for vin, vehicle in _we_connect.vehicles.items():
@@ -50,7 +51,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 vehicles.append(vehicle)
 
         hass.data[DOMAIN][entry.entry_id + "_vehicles"] = vehicles
-        
         return vehicles
 
     coordinator = DataUpdateCoordinator(


### PR DESCRIPTION
I've previously had intermittent issues with the integration hanging after a random period of time. I've been able to diagnose that the problem was that the weconnect update never returned/completed, but I could not figure out why.

This change introduces an extra async timeout layer to the request (`asyncio.wait_for`), and appears to resolve this issue. I've been running this code for several weeks without it hanging.

I've also added a logged warning in the event that the weconnect update exceeds 30s. This is optional. Happy to remove if you'd rather not have this.

The various timeouts could be made configurable, but I am not convinced it's worth it.