### PR TITLE
Fix history for non-numeric sensors and add OverallStatus + DoorLockStatus as Binary Sensors

### DIFF
--- a/custom_components/volkswagen_we_connect_id/binary_sensor.py
+++ b/custom_components/volkswagen_we_connect_id/binary_sensor.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 from weconnect import weconnect
 from weconnect.elements.plug_status import PlugStatus
+from weconnect.elements.access_status import AccessStatus
 from weconnect.elements.window_heating_status import WindowHeatingStatus
 
 from homeassistant.components.binary_sensor import (
@@ -122,6 +123,13 @@ SENSORS: tuple[VolkswagenIdBinaryEntityDescription, ...] = (
         value=lambda data: data["readiness"][
             "readinessStatus"
         ].connectionState.isActive.value,
+    ),
+    VolkswagenIdBinaryEntityDescription(
+        key="overallStatus",
+        name="Overall Status",
+        value=lambda data: data["access"]["accessStatus"].overallStatus.value,
+        device_class=BinarySensorDeviceClass.SAFETY,
+        on_value=AccessStatus.OverallState.UNSAFE,
     ),
 )
 

--- a/custom_components/volkswagen_we_connect_id/binary_sensor.py
+++ b/custom_components/volkswagen_we_connect_id/binary_sensor.py
@@ -131,6 +131,13 @@ SENSORS: tuple[VolkswagenIdBinaryEntityDescription, ...] = (
         device_class=BinarySensorDeviceClass.SAFETY,
         on_value=AccessStatus.OverallState.UNSAFE,
     ),
+    VolkswagenIdBinaryEntityDescription(
+        key="doorLockStatus",
+        name="Door Lock Status",
+        value=lambda data: data["access"]["accessStatus"].doorLockStatus.value,
+        device_class=BinarySensorDeviceClass.LOCK,
+        on_value=AccessStatus.Door.LockState.UNLOCKED,
+    ),
 )
 
 

--- a/custom_components/volkswagen_we_connect_id/manifest.json
+++ b/custom_components/volkswagen_we_connect_id/manifest.json
@@ -3,7 +3,7 @@
   "name": "Volkswagen We Connect ID",
   "config_flow": true,
   "documentation": "https://github.com/mitch-dc/volkswagen_we_connect_id",
-  "requirements": ["weconnect==0.48.1", "ascii_magic==1.6"],
+  "requirements": ["weconnect==0.48.3", "ascii_magic==1.6"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/volkswagen_we_connect_id/sensor.py
+++ b/custom_components/volkswagen_we_connect_id/sensor.py
@@ -225,8 +225,9 @@ class VolkswagenIDSensor(VolkswagenIDBaseEntity, SensorEntity):
         self._coordinator = coordinator
         self._attr_name = f"{self.data.nickname} {sensor.name}"
         self._attr_unique_id = f"{self.data.vin}-{sensor.key}"
-        self._attr_native_unit_of_measurement = sensor.native_unit_of_measurement
-        self._attr_state_class = SensorStateClass.MEASUREMENT
+        if sensor.native_unit_of_measurement:
+            self._attr_native_unit_of_measurement = sensor.native_unit_of_measurement
+            self._attr_state_class = SensorStateClass.MEASUREMENT
 
     @property
     def native_value(self) -> StateType:


### PR DESCRIPTION
Fix:
Non numeric sensors (such as charge type and others) are being created with state_class: MEASUREMENT (and an empty unit of measurement attribute), causing its history to appear as an empty line graph and no logbook entries to exist.

Added functionality:
Bump weconnect version to 0.48.3
Add OverallStatus + DoorLockStatus info as Binary Sensors