### PR TITLE
Sunroof Open Status typo

### DIFF
--- a/custom_components/volkswagen_we_connect_id/sensor.py
+++ b/custom_components/volkswagen_we_connect_id/sensor.py
@@ -248,7 +248,7 @@ SENSORS: tuple[VolkswagenIdEntityDescription, ...] = (
     ),
     VolkswagenIdEntityDescription(
         key="sunRoofStatus",
-        name="Bonnet Open Status",
+        name="Sunroof Open Status",
         value=lambda data: data["access"]["accessStatus"]
         .windows["sunRoof"]
         .openState.value,

--- a/custom_components/volkswagen_we_connect_id/sensor.py
+++ b/custom_components/volkswagen_we_connect_id/sensor.py
@@ -283,7 +283,7 @@ SENSORS: tuple[VolkswagenIdEntityDescription, ...] = (
     ),
     VolkswagenIdEntityDescription(
         key="windowfrontRightOpenStatus",
-        name="Window Front Right Left Open Status",
+        name="Window Front Right Open Status",
         value=lambda data: data["access"]["accessStatus"]
         .windows["frontRight"]
         .openState.value,


### PR DESCRIPTION
'Bonnet Open Status' renamed to 'Sunroof Open Status', due to typo

Typo in "Window Front Right Left Open Status", corrected to "Window Front Right Open Status"