### PR TITLE
Revert back from energy to power sensor device class

### DIFF
--- a/custom_components/volkswagen_we_connect_id/sensor.py
+++ b/custom_components/volkswagen_we_connect_id/sensor.py
@@ -97,7 +97,7 @@ SENSORS: tuple[VolkswagenIdEntityDescription, ...] = (
         key="chargePower_kW",
         name="Charge Power",
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
-        device_class=SensorDeviceClass.energy,
+        device_class=SensorDeviceClass.POWER,
         state_class=measurement,
         value=lambda data: data["charging"]["chargingStatus"].chargePower_kW.value,
     ),


### PR DESCRIPTION
Since Energy and Power are two different things, revert back to the correct state. Sensor displays power.

The State Class "measurement" can stay.