### PR TITLE
Create devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/universal:2",
+    "postCreateCommand": "python .devcontainer/init.py",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python"
+            ]
+        }
+    }
+}

--- a/.devcontainer/init.py
+++ b/.devcontainer/init.py
@@ -1,0 +1,15 @@
+"""
+Initialize container with modules used by volkswage_we_connect_id component
+"""
+
+import json
+import pip
+
+PIP_ARGUMENTS = [ "install", "--user", "homeassistant" ]
+MANIFEST_PATH = "custom_components/volkswagen_we_connect_id/manifest.json"
+
+with open(MANIFEST_PATH, "r", encoding="utf8") as MANIFEST_FILE:
+    MANIFEST = json.load(MANIFEST_FILE)
+    REQUIREMENTS: list[str] = MANIFEST["requirements"]
+
+pip.main(PIP_ARGUMENTS + REQUIREMENTS)


### PR DESCRIPTION
Add a devcontainer configuration file to use with Github Codespaces.

Creates a workspace with Python and the component's dependencies installed, allowing for at least basic syntax checks for contributors.