### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -66,7 +66,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER,
         name=DOMAIN,
         update_method=async_update_data,
-        update_interval=timedelta(seconds=30),
+        update_interval=timedelta(seconds=45),
     )
 
     hass.data.setdefault(DOMAIN, {})


### PR DESCRIPTION
Change refresh time to 45 seconds.  Rate-limiting is causing a 403 error for calls more frequently than 30seconds.  Occasionally the code triggers a call just less than 30 seconds.  A more elegant solution would be to integrate any information from the 429 error code but that will be considerably more work.