### PR TITLE
Prevent weconnect from updating pictures

### DIFF
--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -42,15 +42,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         updateAfterLogin=False,
         loginOnInit=False,
         timeout=10,
+        updatePictures=False,
     )
 
     await hass.async_add_executor_job(_we_connect.login)
-    await hass.async_add_executor_job(_we_connect.update)
+    await hass.async_add_executor_job(update, _we_connect)
 
     async def async_update_data():
         """Fetch data from Volkswagen API."""
 
-        await hass.async_add_executor_job(_we_connect.update)
+        await hass.async_add_executor_job(update, _we_connect)
 
         vehicles = []
 
@@ -170,6 +171,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     return True
 
+
+def update(
+    api: weconnect.WeConnect
+) -> None:
+    """API call to update vehicle information."""
+    api.update(updatePictures=False)
 
 def start_stop_charging(
     call_data_vin, api: weconnect.WeConnect, operation: str

--- a/custom_components/volkswagen_we_connect_id/config_flow.py
+++ b/custom_components/volkswagen_we_connect_id/config_flow.py
@@ -32,17 +32,23 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
         password=data["password"],
         updateAfterLogin=False,
         loginOnInit=False,
+        updatePictures=False,
     )
 
     # TODO: ADD Validation on credentials
 
     await hass.async_add_executor_job(we_connect.login)
-    await hass.async_add_executor_job(we_connect.update)
+    await hass.async_add_executor_job(update, we_connect)
 
     # vin = next(iter(we_connect.vehicles.items()))[0]
 
     return {"title": "Volkswagen We Connect ID"}
 
+def update(
+    api: weconnect.WeConnect
+) -> None:
+    """API call to update vehicle information."""
+    api.update(updatePictures=False)
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Volkswagen We Connect ID."""


### PR DESCRIPTION
Given that pictures are not used by the integration and updating causes unnecessary network calls that often fail.