### PR TITLE
Add weconnect logger to manifest.json

### DIFF
--- a/custom_components/volkswagen_we_connect_id/manifest.json
+++ b/custom_components/volkswagen_we_connect_id/manifest.json
@@ -8,6 +8,7 @@
   "zeroconf": [],
   "homekit": {},
   "dependencies": [],
+  "loggers": ["weconnect"],
   "codeowners": [
     "@mitch-dc"
   ],


### PR DESCRIPTION
Add `weconnect` to the loggers in the `manifest.json` so Home Assistant can generate debug logs from the interface.