### PR TITLE
Update VSCode devcontainer image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "mcr.microsoft.com/devcontainers/universal:2",
+    "image": "mcr.microsoft.com/devcontainers/python:3",
     "postCreateCommand": "python .devcontainer/init.py",
     "customizations": {
         "vscode": {

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Workstation OS files
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
While working on another PR, I found that the VSCode command “Reopen in Container” (devcontainer) was failing with a `"No such image”` error in the devcontainer build logs. I gather that the “universal” image named in `devcontainer.json` is not available for the Apple Silicon (MacBook) CPU architecture:

```sh
$ docker pull mcr.microsoft.com/devcontainers/universal:2
2: Pulling from devcontainers/universal
no matching manifest for linux/arm64/v8 in the manifest list entries

$ docker pull mcr.microsoft.com/devcontainers/universal:latest
latest: Pulling from devcontainers/universal
no matching manifest for linux/arm64/v8 in the manifest list entries
```

The [image description](https://hub.docker.com/_/microsoft-devcontainers) currently includes this note:

> _ARM64 support_
> _Due to [an issue](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=989604) with Debian 10 / Buster and Ubuntu 20.04 / Focal that results in segmentation faults in libssl in a variety of scenarios, we only build arm64 architecture images that use one of the following operating systems:_
> * _Debian 11 / Bullseye_
> * _Ubuntu 18.04 / Bionic_

But the universal image does not seem to be available in those variants. I found that the Python image works fine though:

```
$ docker pull mcr.microsoft.com/devcontainers/python:3
3: Pulling from devcontainers/python
Digest: sha256:a2c4de938fc8c5eb846711e807bfe50a0d809626b0631244441b8d6368590d43
Status: Downloaded newer image for mcr.microsoft.com/devcontainers/python:3
mcr.microsoft.com/devcontainers/python:3
```

Also, I understand that the universal image is a _”large container image_ [that] _includes a number of runtime versions for popular languages like Python, Node, PHP, Java, Go, C++, Ruby, and .NET Core/C#”_ ([ref](https://mcr.microsoft.com/en-us/product/devcontainers/universal/about#description)), whereas the Python image only includes support for Python. But I also understand that only Python is required for Home Assistant development.