### PR TITLE
Fix SyntaxError: invalid syntax (import SourceType.GPS)

### DIFF
--- a/custom_components/volkswagen_we_connect_id/device_tracker.py
+++ b/custom_components/volkswagen_we_connect_id/device_tracker.py
@@ -5,7 +5,7 @@ import logging
 
 from weconnect import weconnect
 
-from homeassistant.components.device_tracker import SourceType.GPS
+from homeassistant.components.device_tracker import SourceType
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect


### PR DESCRIPTION
Following PR #238, my home assistant logs started showing this stack trace:

```txt
2024-02-06 16:25:29.728 ERROR (MainThread) [homeassistant.loader] Unexpected exception importing platform custom_components.volkswagen_we_connect_id.device_tracker
Traceback (most recent call last):
  File "/home/vscode/env/lib/python3.12/site-packages/homeassistant/loader.py", line 842, in get_platform
    cache[full_name] = self._import_platform(platform_name)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/env/lib/python3.12/site-packages/homeassistant/loader.py", line 859, in _import_platform
    return importlib.import_module(f"{self.pkg_path}.{platform_name}")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 990, in exec_module
  File "<frozen importlib._bootstrap_external>", line 1128, in get_code
  File "<frozen importlib._bootstrap_external>", line 1058, in source_to_code
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/home/vscode/.homeassistant/custom_components/volkswagen_we_connect_id/device_tracker.py", line 8
    from homeassistant.components.device_tracker import SourceType.GPS
                                                                  ^
SyntaxError: invalid syntax
```

Indeed:

***Before this PR (after PR #238):***
```python
$ python
Python 3.11.7 (main, Feb  6 2024, 18:04:56) [GCC 12.2.0] on linux

>>> import sys
>>> sys.path.append('custom_components')
>>> from volkswagen_we_connect_id.device_tracker import VolkswagenIDSensor
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/workspaces/volkswagen_we_connect_id/custom_components/volkswagen_we_connect_id/device_tracker.py", line 8
    from homeassistant.components.device_tracker import SourceType.GPS
                                                                  ^
SyntaxError: invalid syntax
```

***After this PR:***
```python
$ python
Python 3.11.7 (main, Feb  6 2024, 18:04:56) [GCC 12.2.0] on linux

>>> import sys
>>> sys.path.append('custom_components')
>>> from volkswagen_we_connect_id.device_tracker import VolkswagenIDSensor
>>> from unittest.mock import MagicMock
>>> s = VolkswagenIDSensor(MagicMock(), MagicMock(), 0)
>>> s.source_type
<SourceType.GPS: 'gps'>
```

Tested with both Python 3.11 and 3.12 — same results.
