### PR TITLE
Prevent multiple simultaneous WeConnect API calls on start up

### DIFF
--- a/custom_components/volkswagen_we_connect_id/config_flow.py
+++ b/custom_components/volkswagen_we_connect_id/config_flow.py
@@ -5,7 +5,6 @@ import logging
 from typing import Any
 
 import voluptuous as vol
-from weconnect import weconnect
 from weconnect.errors import AuthentificationError
 
 from homeassistant import config_entries
@@ -13,6 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 
+from . import get_we_connect_api, update
 from .const import DOMAIN, DEFAULT_UPDATE_INTERVAL_SECONDS, MINIMUM_UPDATE_INTERVAL_SECONDS
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,12 +31,9 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate the user input allows us to connect."""
 
-    we_connect = weconnect.WeConnect(
+    we_connect = get_we_connect_api(
         username=data["username"],
         password=data["password"],
-        updateAfterLogin=False,
-        loginOnInit=False,
-        updatePictures=False,
     )
 
     await hass.async_add_executor_job(we_connect.login)
@@ -46,11 +43,6 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
 
     return {"title": "Volkswagen We Connect ID"}
 
-def update(
-    api: weconnect.WeConnect
-) -> None:
-    """API call to update vehicle information."""
-    api.update(updatePictures=False)
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Volkswagen We Connect ID."""


### PR DESCRIPTION
Thanks for creating and maintaining this integration! 👍 

I have observed that it is the last integration to finish loading whenever I (re)start my Home Assistant instance. I have found that, when the integration starts, it makes 6 calls to the WeConnect API `update()` method nearly at once — the same [`api.update()`](https://github.com/mitch-dc/volkswagen_we_connect_id/blob/v0.2.0/custom_components/volkswagen_we_connect_id/__init__.py#L179) call that is normally made every [45 seconds](https://github.com/mitch-dc/volkswagen_we_connect_id/blob/v0.2.0/custom_components/volkswagen_we_connect_id/__init__.py#L70). Each such call results in 6 HTTP GET requests to the following VW/Cariad endpoints:

1. `https://emea.bff.cariad.digital/vehicle/v1/vehicles`
2. `https://emea.bff.cariad.digital/vehicle/v1/vehicles/<VIN>/selectivestatus?jobs=access,activeventilation,automation,auxiliaryheating,userCapabilities,charging,chargingProfiles,batteryChargingCare,climatisation,climatisationTimers,departureTimers,fuelStatus,vehicleLights,lvBattery,readiness,vehicleHealthInspection,vehicleHealthWarnings,oilLevel,measurements,batterySupport,trips`
3. `https://emea.bff.cariad.digital/vehicle/v1/vehicles/<VIN>/parkingposition`
4. `https://emea.bff.cariad.digital/vehicle/v1/trips/<VIN>/shortterm/last`
5. `https://emea.bff.cariad.digital/vehicle/v1/trips/<VIN>/longterm/last`
6. `https://emea.bff.cariad.digital/vehicle/v1/trips/<VIN>/cyclic/last`

So 6 × 6 = 36 authenticated API endpoint requests within a few seconds from the integration being loaded (in my logs I observed all HTTP requests being _started_ within 3 seconds of the integration loading). In addition, when the config flow executes during installation, an extra `api.update()` call is made for username and password validation, in which case it is 7 × 6 = 42 authenticated API endpoint requests just a few seconds apart.

2 of the 6 or 7 `update()` calls are explicit, and the others happen as a result of calls to `coordinator.async_config_entry_first_refresh()`:

1. [`__init__.py#L49`](https://github.com/mitch-dc/volkswagen_we_connect_id/blob/v0.2.0/custom_components/volkswagen_we_connect_id/__init__.py#L49)
2. [`__init__.py#L79`](https://github.com/mitch-dc/volkswagen_we_connect_id/blob/v0.2.0/custom_components/volkswagen_we_connect_id/__init__.py#L79)
3. [`binary_sensor.py#L139`](https://github.com/mitch-dc/volkswagen_we_connect_id/blob/v0.2.0/custom_components/volkswagen_we_connect_id/binary_sensor.py#L139)
4. [`device_tracker.py#L29`](https://github.com/mitch-dc/volkswagen_we_connect_id/blob/v0.2.0/custom_components/volkswagen_we_connect_id/device_tracker.py#L29)
5. [`number.py#L29`](https://github.com/mitch-dc/volkswagen_we_connect_id/blob/v0.2.0/custom_components/volkswagen_we_connect_id/number.py#L29)
6. [`sensor.py#L448`](https://github.com/mitch-dc/volkswagen_we_connect_id/blob/v0.2.0/custom_components/volkswagen_we_connect_id/sensor.py#L448)
7. [`config_flow.py#L41`](https://github.com/mitch-dc/volkswagen_we_connect_id/blob/v0.2.0/custom_components/volkswagen_we_connect_id/config_flow.py#L41)

I have verified this finding by adding debug logging at the relevant WeConnect fetchData [`session.get()`](https://github.com/tillsteinbach/WeConnect-python/blob/v0.59.5/weconnect/weconnect.py#L373) call.

A single WeConnect API `update()` call would be sufficient at start up. This PR proposes a relatively simple solution to achieve this, even in the config flow scenario when the integration is installed.

I tested my solution with HASS version 2024.1.6, including the case of the user entering incorrect username and password in the config flow. I have also exercised the code added to `async_unload_entry()` by deleting and re-adding the integration.
