### PR TITLE
Improve authentication error handling in config flow

### DIFF
--- a/custom_components/volkswagen_we_connect_id/config_flow.py
+++ b/custom_components/volkswagen_we_connect_id/config_flow.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import voluptuous as vol
 from weconnect import weconnect
+from weconnect.errors import AuthentificationError
 
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
@@ -34,8 +35,6 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
         loginOnInit=False,
         updatePictures=False,
     )
-
-    # TODO: ADD Validation on credentials
 
     await hass.async_add_executor_job(we_connect.login)
     await hass.async_add_executor_job(update, we_connect)
@@ -70,7 +69,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             info = await validate_input(self.hass, user_input)
         except CannotConnect:
             errors["base"] = "cannot_connect"
-        except InvalidAuth:
+        except AuthentificationError:
             errors["base"] = "invalid_auth"
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception("Unexpected exception")
@@ -85,7 +84,3 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 class CannotConnect(HomeAssistantError):
     """Error to indicate we cannot connect."""
-
-
-class InvalidAuth(HomeAssistantError):
-    """Error to indicate there is invalid auth."""


### PR DESCRIPTION
Before this PR, entering an incorrect username or password in the config flow would cause the form to display “Unexpected error”, while the hass logs would print _“Unexpected exception”_ and a stack trace:

![Unexpected Error](https://github.com/mitch-dc/volkswagen_we_connect_id/assets/15091591/37408b61-c1ab-46bd-ab64-5e7cb7bc7fe8)

```
2024-02-09 18:25:24.786 ERROR (MainThread) [custom_components.volkswagen_we_connect_id.config_flow] Unexpected exception
Traceback (most recent call last):
  File "/home/vscode/.homeassistant/custom_components/volkswagen_we_connect_id/config_flow.py", line 62, in async_step_user
    info = await validate_input(self.hass, user_input)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.homeassistant/custom_components/volkswagen_we_connect_id/config_flow.py", line 37, in validate_input
    await hass.async_add_executor_job(we_connect.login)
  File "/usr/local/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.local/lib/python3.12/site-packages/weconnect/weconnect.py", line 187, in login
    self.__session.login()
  File "/home/vscode/.local/lib/python3.12/site-packages/weconnect/auth/we_connect_session.py", line 76, in login
    response = self.doWebAuth(authorizationUrl)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.local/lib/python3.12/site-packages/weconnect/auth/we_connect_session.py", line 198, in doWebAuth
    raise AuthentificationError(f'Error during login, account {self.sessionuser.username} does not exist')
weconnect.errors.AuthentificationError: Error during login, account foo@example.com does not exist
```

The last line above might also be:

```
weconnect.errors.AuthentificationError: Error during login, email invalid
```

After this PR, nothing is printed in the hass logs (at least not with my default log level), and the user interface displays a seemingly hass-standard “Invalid authentication” message:

![Invalid Authentication](https://github.com/mitch-dc/volkswagen_we_connect_id/assets/15091591/72d8ae07-61ff-4be9-abf8-0e908ee8f11e)

The reason why I was messing with that is that I was testing my code changes in another PR, #245.
