### PR TITLE
Make the update interval configurable

### DIFF
--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from .const import DOMAIN
+from .const import DOMAIN, DEFAULT_UPDATE_INTERVAL_SECONDS
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -67,7 +67,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER,
         name=DOMAIN,
         update_method=async_update_data,
-        update_interval=timedelta(seconds=45),
+        update_interval=timedelta(
+            seconds=entry.data.get("update_interval") or DEFAULT_UPDATE_INTERVAL_SECONDS,
+        ),
     )
 
     hass.data.setdefault(DOMAIN, {})

--- a/custom_components/volkswagen_we_connect_id/config_flow.py
+++ b/custom_components/volkswagen_we_connect_id/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 
-from .const import DOMAIN
+from .const import DOMAIN, DEFAULT_UPDATE_INTERVAL_SECONDS, MINIMUM_UPDATE_INTERVAL_SECONDS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -20,6 +20,9 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required("username"): str,
         vol.Required("password"): str,
+        vol.Optional(
+            "update_interval", default=DEFAULT_UPDATE_INTERVAL_SECONDS
+        ): vol.All(vol.Coerce(int), vol.Range(min=MINIMUM_UPDATE_INTERVAL_SECONDS)),
     }
 )
 
@@ -54,6 +57,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Volkswagen We Connect ID."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/volkswagen_we_connect_id/const.py
+++ b/custom_components/volkswagen_we_connect_id/const.py
@@ -1,3 +1,6 @@
 """Constants for the Volkswagen We Connect ID integration."""
 
 DOMAIN = "volkswagen_we_connect_id"
+
+DEFAULT_UPDATE_INTERVAL_SECONDS = 45
+MINIMUM_UPDATE_INTERVAL_SECONDS = 30

--- a/custom_components/volkswagen_we_connect_id/strings.json
+++ b/custom_components/volkswagen_we_connect_id/strings.json
@@ -5,7 +5,8 @@
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
+          "password": "[%key:common::config_flow::data::password%]",
+          "update_interval": "Update interval (seconds)"
         }
       }
     },

--- a/custom_components/volkswagen_we_connect_id/translations/en.json
+++ b/custom_components/volkswagen_we_connect_id/translations/en.json
@@ -13,7 +13,8 @@
                 "data": {
                     "host": "Host",
                     "password": "Password",
-                    "username": "Username"
+                    "username": "Username",
+                    "update_interval": "Update interval (seconds)"
                 }
             }
         }


### PR DESCRIPTION
This PR is an attempt to revive @tsg21’s effort in PR #72, created more than a year ago but which got stalled for apparently two reasons:
* The proposed config flow changes not being displayed in the UI for an unknown reason.
* The PR’s author and the repo’s maintainer not converging on a default update interval value.

This PR addresses those points by:
* Fixing the voluptuous schema data type for the `update_interval` option.
* Keeping the default update interval value unchanged from what it currently is: [45 seconds](https://github.com/mitch-dc/volkswagen_we_connect_id/blob/v0.2.0/custom_components/volkswagen_we_connect_id/__init__.py#L70). The vast majority of users will presumably just go with the default, but concerned users will be allowed to change the update interval through the UI if / when the integration is (re)installed:

<img width="411" alt="config-flow-update-interva" src="https://github.com/mitch-dc/volkswagen_we_connect_id/assets/15091591/0b268ca4-a92e-47f5-b0f1-44663c9eda23"> 

“99%” of the code is a copy-and-paste from PR #72, so credit goes to @tsg21. I have added the value of investigating and fixing the UI issue.

This PR is also related to issues #211, #215 and #222 insofar as reducing the polling frequency reportedly avoids WeConnect API errors (e.g. 403, 429) when the servers are busy (API call rate limiting / throttling).