### PR TITLE
Refactor code to improve static type checking (DomainEntry dataclass)

### DIFF
--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -1,11 +1,13 @@
 """The Volkswagen We Connect ID integration."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import timedelta
 import logging
 import asyncio
 import time
 from weconnect import weconnect
+from weconnect.elements.vehicle import Vehicle
 from weconnect.elements.control_operation import ControlOperation
 
 from homeassistant.config_entries import ConfigEntry
@@ -32,6 +34,15 @@ _LOGGER = logging.getLogger(__name__)
 SUPPORTED_VEHICLES = ["ID.3", "ID.4", "ID.5", "ID. Buzz"]
 
 
+@dataclass
+class DomainEntry:
+    """References to objects shared through hass.data[DOMAIN][config_entry_id]."""
+
+    coordinator: DataUpdateCoordinator[list[Vehicle]]
+    we_connect: weconnect.WeConnect
+    vehicles: list[Vehicle]
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Volkswagen We Connect ID from a config entry."""
 
@@ -48,21 +59,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.async_add_executor_job(_we_connect.login)
     await hass.async_add_executor_job(update, _we_connect)
 
-    async def async_update_data():
+    async def async_update_data() -> list[Vehicle]:
         """Fetch data from Volkswagen API."""
 
         await hass.async_add_executor_job(update, _we_connect)
 
-        vehicles = []
+        vehicles: list[Vehicle] = []
 
         for vin, vehicle in _we_connect.vehicles.items():
             if vehicle.model.value in SUPPORTED_VEHICLES:
                 vehicles.append(vehicle)
 
-        hass.data[DOMAIN][entry.entry_id + "_vehicles"] = vehicles
+        domain_entry: DomainEntry = hass.data[DOMAIN][entry.entry_id]
+        domain_entry.vehicles = vehicles
         return vehicles
 
-    coordinator = DataUpdateCoordinator(
+    coordinator = DataUpdateCoordinator[list[Vehicle]](
         hass,
         _LOGGER,
         name=DOMAIN,
@@ -70,10 +82,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         update_interval=timedelta(seconds=45),
     )
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id + "_coordinator"] = coordinator
-    hass.data[DOMAIN][entry.entry_id] = _we_connect
-    hass.data[DOMAIN][entry.entry_id + "_vehicles"] = []
+    hass.data[DOMAIN][entry.entry_id] = DomainEntry(coordinator, _we_connect, [])
 
     # Fetch initial data so we have data when entities subscribe
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/volkswagen_we_connect_id/binary_sensor.py
+++ b/custom_components/volkswagen_we_connect_id/binary_sensor.py
@@ -9,14 +9,17 @@ from weconnect.elements.plug_status import PlugStatus
 from weconnect.elements.lights_status import LightsStatus
 from weconnect.elements.window_heating_status import WindowHeatingStatus
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from . import VolkswagenIDBaseEntity, get_object_value
+from . import DomainEntry, VolkswagenIDBaseEntity
 from .const import DOMAIN
 
 
@@ -129,11 +132,15 @@ SENSORS: tuple[VolkswagenIdBinaryEntityDescription, ...] = (
 )
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
     """Add sensors for passed config_entry in HA."""
-    we_connect: weconnect.WeConnect
-    we_connect = hass.data[DOMAIN][config_entry.entry_id]
-    coordinator = hass.data[DOMAIN][config_entry.entry_id + "_coordinator"]
+    domain_entry: DomainEntry = hass.data[DOMAIN][config_entry.entry_id]
+    we_connect = domain_entry.we_connect
+    coordinator = domain_entry.coordinator
 
     # Fetch initial data so we have data when entities subscribe
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/volkswagen_we_connect_id/button.py
+++ b/custom_components/volkswagen_we_connect_id/button.py
@@ -3,15 +3,29 @@ from weconnect import weconnect
 from weconnect.elements.vehicle import Vehicle
 
 from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import get_object_value, set_ac_charging_speed, set_climatisation, start_stop_charging
+from . import (
+    DomainEntry,
+    get_object_value,
+    set_ac_charging_speed,
+    set_climatisation,
+    start_stop_charging,
+)
 from .const import DOMAIN
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> bool:
     """Add buttons for passed config_entry in HA."""
-    we_connect = hass.data[DOMAIN][config_entry.entry_id]
-    vehicles = hass.data[DOMAIN][config_entry.entry_id + "_vehicles"]
+    domain_entry: DomainEntry = hass.data[DOMAIN][config_entry.entry_id]
+    we_connect = domain_entry.we_connect
+    vehicles = domain_entry.vehicles
 
     entities = []
     for vehicle in vehicles:  # weConnect.vehicles.items():

--- a/custom_components/volkswagen_we_connect_id/device_tracker.py
+++ b/custom_components/volkswagen_we_connect_id/device_tracker.py
@@ -7,23 +7,29 @@ from weconnect import weconnect
 
 from homeassistant.components.device_tracker import SourceType.GPS
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import slugify
 
-from . import VolkswagenIDBaseEntity, get_object_value
+from . import DomainEntry, VolkswagenIDBaseEntity, get_object_value
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
     """Add sensors for passed config_entry in HA."""
 
-    we_connect: weconnect.WeConnect
-    we_connect = hass.data[DOMAIN][config_entry.entry_id]
-    coordinator = hass.data[DOMAIN][config_entry.entry_id + "_coordinator"]
+    domain_entry: DomainEntry = hass.data[DOMAIN][config_entry.entry_id]
+    we_connect = domain_entry.we_connect
+    coordinator = domain_entry.coordinator
 
     # Fetch initial data so we have data when entities subscribe
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/volkswagen_we_connect_id/number.py
+++ b/custom_components/volkswagen_we_connect_id/number.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 from weconnect import weconnect
 
 from homeassistant.components.number import NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import (
+    DomainEntry,
     VolkswagenIDBaseEntity,
     get_object_value,
     set_climatisation,
@@ -21,11 +25,15 @@ from homeassistant.const import (
 )
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
     """Add buttons for passed config_entry in HA."""
-    we_connect: weconnect.WeConnect
-    we_connect = hass.data[DOMAIN][config_entry.entry_id]
-    coordinator = hass.data[DOMAIN][config_entry.entry_id + "_coordinator"]
+    domain_entry: DomainEntry = hass.data[DOMAIN][config_entry.entry_id]
+    we_connect = domain_entry.we_connect
+    coordinator = domain_entry.coordinator
 
     # Fetch initial data so we have data when entities subscribe
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/volkswagen_we_connect_id/sensor.py
+++ b/custom_components/volkswagen_we_connect_id/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
     SensorDeviceClass,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
     UnitOfPower,
@@ -22,12 +23,12 @@ from homeassistant.const import (
     UnitOfSpeed,
     UnitOfTime,
 )
-
-
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from . import VolkswagenIDBaseEntity, get_object_value
+from . import DomainEntry, VolkswagenIDBaseEntity, get_object_value
 from .const import DOMAIN
 
 
@@ -442,11 +443,16 @@ VEHICLE_SENSORS: tuple[VolkswagenIdEntityDescription, ...] = (
 
 )
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
     """Add sensors for passed config_entry in HA."""
-    we_connect: weconnect.WeConnect
-    we_connect = hass.data[DOMAIN][config_entry.entry_id]
-    coordinator = hass.data[DOMAIN][config_entry.entry_id + "_coordinator"]
+    domain_entry: DomainEntry = hass.data[DOMAIN][config_entry.entry_id]
+    we_connect = domain_entry.we_connect
+    coordinator = domain_entry.coordinator
 
     # Fetch initial data so we have data when entities subscribe
     await coordinator.async_config_entry_first_refresh()


### PR DESCRIPTION
This PR does not provide any user-visible features, but it provides two development benefits:

1. It replaces the computation of the following dictionary keys (string concatenation), which was found in copy-and-paste form across 6 files:

```python
we_connect = hass.data[DOMAIN][config_entry.entry_id]
coordinator = hass.data[DOMAIN][config_entry.entry_id + "_coordinator"]
vehicles = hass.data[DOMAIN][config_entry.entry_id + "_vehicles”]
```

... with a `DomainEntry` dataclass that allows the following usage:

```python
domain_entry: DomainEntry = hass.data[DOMAIN][config_entry.entry_id]
we_connect = domain_entry.we_connect
coordinator = domain_entry.coordinator
vehicles = domain_entry.vehicles
```

In the original form, the IDE (VSCode + Pylance) and linters / type checkers like `pylint` and `pyright` could not tell the types of variables `we_connect`, `coordinator` and `vehicles`, which were deemed ’unknown’ and affected a chain of type checking wherever those variables were used. In the second form proposed in this PR, type checking is available.

2. It adds more type hints in several selected functions and several selected files, which again allows the IDE / `pylint` / `pyright` to aid with type checking.

Tested with Home Assistant version `2024.1.6`.