### PR TITLE
Add support for Volkswagen Multivan (Transporter 7)

### DIFF
--- a/custom_components/volkswagen_we_connect_id/__init__.py
+++ b/custom_components/volkswagen_we_connect_id/__init__.py
@@ -29,7 +29,7 @@ PLATFORMS = [
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORTED_VEHICLES = ["ID.3", "ID.4", "ID.5", "ID. Buzz"]
+SUPPORTED_VEHICLES = ["ID.3", "ID.4", "ID.5", "ID. Buzz", "Transporter 7"]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:


### PR DESCRIPTION
It seems many more cars are compatible with this API, however not every sensor is available.

This PR is dependant on https://github.com/mitch-dc/volkswagen_we_connect_id/pull/204

Similar to (and probably conflicts with) https://github.com/mitch-dc/volkswagen_we_connect_id/pull/202