### PR TITLE
Catching TypeError in native_value

### DIFF
--- a/custom_components/volkswagen_we_connect_id/sensor.py
+++ b/custom_components/volkswagen_we_connect_id/sensor.py
@@ -498,7 +498,7 @@ class VolkswagenIDSensor(VolkswagenIDBaseEntity, SensorEntity):
 
         try:
             state = get_object_value(self.entity_description.value(self.data.domains))
-        except (KeyError, ValueError):
+        except (TypeError, KeyError, ValueError):
             return None
 
         return cast(StateType, state)


### PR DESCRIPTION
I see this in my logs over and over again:
```
2024-05-12 14:08:55.066 WARNING (SyncWorker_3) [weconnect] /vehicles/WVGZZZE2ZMP017331: Unknown attribute temperatureOutsideStatus with value {'error': {'message': 'Bad Gateway', 'errorTimeStamp': '2024-05-12T12:08:53Z', 'info': 'Upstream service responded with an unexpected status. If the problem persists, please contact our support.', 'code': 4007, 'group': 2, 'retry': True}} in domain measurements
2024-05-12 14:08:55.809 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 258, in _handle_refresh_interval
    await self._async_refresh(log_failures=True, scheduled=True)
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 414, in _async_refresh
    self.async_update_listeners()
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 168, in async_update_listeners
    update_callback()
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 492, in _handle_coordinator_update
    self.async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1009, in async_write_ha_state
    self._async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1132, in _async_write_ha_state
    state, attr, capabilities, shadowed_attr = self.__async_calculate_state()
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1067, in __async_calculate_state
    state = self._stringify_state(available)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1015, in _stringify_state
    if (state := self.state) is None:
                 ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 543, in state
    value = self.native_value
            ^^^^^^^^^^^^^^^^^
  File "/config/custom_components/volkswagen_we_connect_id/sensor.py", line 499, in native_value
    state = get_object_value(self.entity_description.value(self.data.domains))
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/volkswagen_we_connect_id/sensor.py", line 48, in function
    return data["measurements"][
           ^^^^^^^^^^^^^^^^^^^^^
TypeError: unsupported operand type(s) for -: 'NoneType' and 'float'
```

The fix in this PR will at least catch the error and avoid flooding the logs with a stack trace. I guess there are other things that could be fixed as well (Bad Gateway seems bad) but I don't know enough about this code base to fix those things as well.