### PR TITLE
Bump weconnect to 0.60.4

### DIFF
--- a/custom_components/volkswagen_we_connect_id/manifest.json
+++ b/custom_components/volkswagen_we_connect_id/manifest.json
@@ -3,7 +3,7 @@
   "name": "Volkswagen We Connect ID",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/volkswagen_we_connect_id",
-  "requirements": ["weconnect==0.60.3", "ascii_magic>=2.0.0"],
+  "requirements": ["weconnect==0.60.4", "ascii_magic>=2.0.0"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},


### PR DESCRIPTION
Bump weconnect dependency to version 0.60.4.

This fixes the following warnings in the logs for me:
```
WARNING (SyncWorker_2) [weconnect] /vehicles/<redacted>/domains/automation/chargingProfiles/profiles/1/options: Unknown attribute usePrivateCurrentEnabled with value True
WARNING (SyncWorker_2) [weconnect] /vehicles/<redacted>/domains/charging/chargingStatus: Unknown attribute chargingScenario with value off
WARNING (SyncWorker_2) [weconnect] /vehicles/<redacted>/domains/chargingProfiles/chargingProfilesStatus/profiles/1/options: Unknown attribute usePrivateCurrentEnabled with value True
```