### PR TITLE
Add parking time to device tracker

### DIFF
--- a/custom_components/volkswagen_we_connect_id/device_tracker.py
+++ b/custom_components/volkswagen_we_connect_id/device_tracker.py
@@ -88,3 +88,17 @@ class VolkswagenIDSensor(VolkswagenIDBaseEntity, TrackerEntity):
     def icon(self):
         """Return the icon."""
         return "mdi:car"
+
+    @property
+    def extra_state_attributes(self):
+        """Return timestamp of when the data was captured."""
+        try:
+            return {
+                "last_captured": get_object_value(
+                    self.data.domains["parking"][
+                        "parkingPosition"
+                    ].carCapturedTimestamp.value
+                )
+            }
+        except KeyError:
+            return None


### PR DESCRIPTION
Adds a last_captured attribute to the parking position device tracker.
It gives the approximate time the car was parked.